### PR TITLE
Added ability to specify fallback URL if ext is not properly detected

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,12 +18,17 @@ type CacheEntry = {
 
 export class ImageCache {
 
-    private getPath(uri: string, immutable?: boolean): string {
-        const ext =
+    private getPath(uri: string, immutable?: boolean, fallback_ext: string = ".jpg"): string {
+        let ext =
             uri.indexOf("?") === -1 ?
                 uri.substring(uri.lastIndexOf("."))
             :
                 uri.substring(uri.lastIndexOf("."), uri.indexOf("?"));
+
+        if (ext.length > 5 || ext.length < 3) {
+            ext = fallback_ext;
+        }
+
         if (immutable === true) {
             return BASE_DIR + "/" + SHA1(uri) + ext;
         } else {


### PR DESCRIPTION
Currently, if remote URL doesn't contain extension (.jpg, .png) - detected extension is not correct and image is not displayed at all.

For example, some of our images are in format:
```
http://api.pudelek.pl.sds.o2.pl/e7d2bea5489b34b0f1733efb02e22ded22957aea/17586601_400141987027307_92129543875198976_n-jpg_apiv4_1082_748
```

Current code detects following extension:
```
.pl/e7d2bea5489b34b0f1733efb02e22ded22957aea/17586601_400141987027307_92129543875198976_n-jpg_apiv4_1082_748
```

which is obviously not correct.

Pull request solves the problem.