### PR TITLE
RNFetchBlob fetch params

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -94,7 +94,6 @@ export class ImageCache {
     }
 
     private download(uri: string, cache: CacheEntry) {
-      console.log('cache.requestParams', cache.requestParams);
         if (!cache.downloading) {
             const path = this.getPath(uri, cache.immutable);
             cache.downloading = true;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ type CacheEntry = {
     handlers: CacheHandler[];
     path: string | undefined;
     immutable: boolean;
+    requestParams: any;
     task?: any;
 };
 
@@ -51,12 +52,13 @@ export class ImageCache {
         return RNFetchBlob.fs.unlink(BASE_DIR);
     }
 
-    on(uri: string, handler: CacheHandler, immutable?: boolean) {
+    on(uri: string, handler: CacheHandler, immutable?: boolean, requestParams?: any) {
         if (!this.cache[uri]) {
             this.cache[uri] = {
                 downloading: false,
                 handlers: [handler],
                 immutable: immutable === true,
+                requestParams: requestParams || {},
                 path: immutable === true ? this.getPath(uri, immutable) : undefined
             };
         } else {
@@ -92,10 +94,11 @@ export class ImageCache {
     }
 
     private download(uri: string, cache: CacheEntry) {
+      console.log('cache.requestParams', cache.requestParams);
         if (!cache.downloading) {
             const path = this.getPath(uri, cache.immutable);
             cache.downloading = true;
-            cache.task = RNFetchBlob.config({ path }).fetch("GET", uri, {});
+            cache.task = RNFetchBlob.config({ path }).fetch("GET", uri, cache.requestParams);
             cache.task.then(() => {
                 cache.downloading = false;
                 cache.path = path;
@@ -135,7 +138,7 @@ export class ImageCache {
 
 export interface CachedImageProps extends ImageProperties {
     mutable?: boolean;
-
+    requestParams?: any;
 }
 
 export interface CustomCachedImageProps extends CachedImageProps {
@@ -149,6 +152,7 @@ export interface CachedImageState {
 export abstract class BaseCachedImage<P extends CachedImageProps> extends Component<P, CachedImageState>  {
 
     private uri: string;
+    private requestParams: any;
 
     private handler: CacheHandler = (path: string) => {
         this.setState({ path });
@@ -165,11 +169,12 @@ export abstract class BaseCachedImage<P extends CachedImageProps> extends Compon
         }
     }
 
-    private observe(uri: string, mutable: boolean) {
+    private observe(uri: string, mutable: boolean, requestParams: any) {
         if (uri !== this.uri) {
             this.dispose();
             this.uri = uri;
-            ImageCache.get().on(uri, this.handler, !mutable);
+            this.requestParams = requestParams;
+            ImageCache.get().on(uri, this.handler, !mutable, requestParams);
         }
     }
 
@@ -178,7 +183,7 @@ export abstract class BaseCachedImage<P extends CachedImageProps> extends Compon
         Object.keys(this.props).forEach(prop => {
             if (prop === "source") {
                 props["source"] = this.state.path ? {uri: FILE_PREFIX + this.state.path} : {};
-            } else if (["mutable", "component"].indexOf(prop) === -1) {
+            } else if (["mutable", "component", "requestParams"].indexOf(prop) === -1) {
                 props[prop] = (this.props as any)[prop];
             }
         });
@@ -186,14 +191,14 @@ export abstract class BaseCachedImage<P extends CachedImageProps> extends Compon
     }
 
     componentWillMount() {
-        const {mutable} = this.props;
+        const {mutable, requestParams} = this.props;
         const source = this.props.source as ImageURISource;
-        this.observe(source.uri as string, mutable === true);
+        this.observe(source.uri as string, mutable === true, requestParams);
     }
 
     componentWillReceiveProps(nextProps: P) {
-        const {source, mutable} = nextProps;
-        this.observe((source as ImageURISource).uri as string, mutable === true);
+        const {source, mutable, requestParams} = nextProps;
+        this.observe((source as ImageURISource).uri as string, mutable === true, requestParams);
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
Thanks for the lib.

I needed to add Authorization headers for some images I am requesting, but wanted to use your library. So I added the ability to pass params to the `fetch` method in `download`.

If you want to merge this, let me know if you want any changes. I'm not familiar with TypeScript, but I linted it using their tool and got no errors, apart from some TouchEvent stuff, which I don't think is related:

    369     interface TouchEvent<T> extends SyntheticEvent<T> {
                      ~~~~~~~~~~
    node_modules/@types/react/index.d.ts(369,15): error TS2430: Interface 'TouchEvent<T>' incorrectly extends interface 'SyntheticEvent<T>'.
      Types of property 'nativeEvent' are incompatible.
        Type 'NativeTouchEvent' is not assignable to type 'Event'.
          Property 'bubbles' is missing in type 'NativeTouchEvent'.

    427     type TouchEventHandler<T> = EventHandler<TouchEvent<T>>;
                                                     ~~~~~~~~~~~~~
    node_modules/@types/react/index.d.ts(427,46): error TS2344: Type 'TouchEvent<T>' does not satisfy the constraint 'SyntheticEvent<any>'.
      Types of property 'nativeEvent' are incompatible.

