### PR TITLE
Remove colons from the file extension when caching an image.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,7 +26,7 @@ export class ImageCache {
     private getPath(uri: string, immutable?: boolean): string {
         let path = uri.substring(uri.lastIndexOf("/"));
         path = path.indexOf("?") === -1 ? path : path.substring(path.lastIndexOf("."), path.indexOf("?"));
-        const ext = path.indexOf(".") === -1 ? ".jpg" : path.substring(path.indexOf("."));
+        const ext = path.indexOf(".") === -1 ? ".jpg" : path.substring(path.indexOf(".")).replace(':', '_');
         if (immutable === true) {
             return BASE_DIR + "/" + SHA1(uri) + ext;
         } else {


### PR DESCRIPTION
iOS doesn’t like having colons in filenames, and Twitter uses colons to identify the size of an image after the filename, e.g. ‘https://pbs.twimg.com/media/foo.jpg:large’, and this library was using the colon in the extension which resulted in images not displaying. The solution was to replace the colons in the extension. (Issue came to light due to using OpenGraph lookups to get appropriate images for embedded tweets)