### PR TITLE
Add ImageBackground

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React, {Component} from "react";
-import {Image, ImageProperties, ImageURISource, Platform} from "react-native";
+import {Image, ImageBackground, ImageProperties, ImageURISource, Platform} from "react-native";
 import RNFetchBlob from "react-native-fetch-blob";
 const SHA1 = require("crypto-js/sha1");
 
@@ -231,6 +231,18 @@ export class CachedImage extends BaseCachedImage<CachedImageProps> {
     render() {
         const props = this.getProps();
         return <Image {...props}>{this.props.children}</Image>;
+    }
+}
+
+export class CachedImageBackground extends BaseCachedImage<CachedImageProps> {
+
+    constructor() {
+        super();
+    }
+
+    render() {
+        const props = this.getProps();
+        return <ImageBackground {...props}>{this.props.children}</ImageBackground>;
     }
 }
 


### PR DESCRIPTION
To remove deprecation warning: http://facebook.github.io/react-native/releases/0.49/docs/images.html#background-image-via-nesting

This component can basically be written `<CustomCachedImage component={ImageBackground} />` but is much more intuitive to use like this imho.