### PR TITLE
Change react-native-fetch-blob to rn-fetch-blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Starting version `0.43`, the React Native [Image component](https://facebook.git
 
 ## Installation
 
-### react-native-fetch-blob
-This package has a dependency with [react-native-fetch-blob](https://github.com/wkh237/react-native-fetch-blob).
-If your project doesn't have a dependency with this package already, please refer to [their installation instructions](https://github.com/wkh237/react-native-fetch-blob#user-content-installation).
+### rn-fetch-blob
+This package has a dependency with [rn-fetch-blob](https://github.com/joltup/rn-fetch-blob).
+If your project doesn't have a dependency with this package already, please refer to [their installation instructions](https://github.com/joltup/rn-fetch-blob#user-content-installation).
 
 ```bash
 npm install react-native-img-cache --save

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,1 +1,1 @@
-declare module "react-native-fetch-blob";
+declare module "rn-fetch-blob";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
 import {Image, ImageBackground, ImageProperties, ImageURISource, Platform} from "react-native";
-import RNFetchBlob from "react-native-fetch-blob";
+import RNFetchBlob from "rn-fetch-blob";
 const SHA1 = require("crypto-js/sha1");
 
 const s4 = () => Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
@@ -108,7 +108,6 @@ export class ImageCache {
                 this.notify(uri);
             }).catch(() => {
                 cache.downloading = false;
-                // Parts of the image may have been downloaded already, (see https://github.com/wkh237/react-native-fetch-blob/issues/331)
                 RNFetchBlob.fs.unlink(path);
             });
         }


### PR DESCRIPTION
[react-native-fetch-blob](https://github.com/wkh237/react-native-fetch-blob#new-maintainers-and-repository-location) is no longer being actively maintained so it is advised to switch over to [rn-fetch-blob](https://github.com/joltup/rn-fetch-blob)

This fix should resolve [Issue 95](https://github.com/wcandillon/react-native-img-cache/issues/95)