### PR TITLE
fixing typings for image to support the latest react native image types

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/wcandillon/react-native-img-cache#readme",
   "devDependencies": {
     "@types/react": "^16.0.5",
-    "@types/react-native": "^0.49.2",
+    "@types/react-native": "^0.55.0",
     "ts-npm-lint": "^0.1.0",
     "tslint": "^4.4.2",
     "typescript": "^2.1.6"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React, {Component} from "react";
-import {Image, ImageBackground, ImageProperties, ImageURISource, Platform} from "react-native";
+import {Image, ImageBackground, ImageProps, ImageURISource, Platform} from "react-native";
 import RNFetchBlob from "rn-fetch-blob";
 const SHA1 = require("crypto-js/sha1");
 
@@ -138,7 +138,7 @@ export class ImageCache {
     }
 }
 
-export interface CachedImageProps extends ImageProperties {
+export interface CachedImageProps extends ImageProps {
     mutable?: boolean;
 
 }


### PR DESCRIPTION
`ImageProperties` are deprecated in the latest typings for react native .
This pull request fixes the issue by using the `ImageProps` instead of `ImageProperties`